### PR TITLE
Submission: KOReader stock by AndyHazz

### DIFF
--- a/presets/koreader-stock.lua
+++ b/presets/koreader-stock.lua
@@ -1,0 +1,214 @@
+-- Bookends preset: KOReader stock
+return {
+    author = "AndyHazz",
+    bar_colors = {
+        border = 0,
+        border_thickness = 2,
+        invert_read_ticks = false,
+        tick_height_pct = 80,
+    },
+    defaults = {
+        font_scale = 100,
+        font_size = 14,
+        margin_bottom = 0,
+        margin_left = 21,
+        margin_right = 21,
+        margin_top = 10,
+        overlap_gap = 50,
+        truncation_priority = "sides",
+    },
+    description = "Mimics KOReader's built-in status bar — page, clock, chapter, battery, percent, time remaining",
+    name = "KOReader stock",
+    positions = {
+        bc = {
+            lines = {
+            },
+        },
+        bl = {
+            disabled = true,
+            line_bar_height = {
+            },
+            line_bar_style = {
+            },
+            line_bar_type = {
+            },
+            line_font_face = {
+            },
+            line_font_size = {
+            },
+            line_h_nudge = {
+            },
+            line_page_filter = {
+            },
+            line_style = {
+            },
+            line_uppercase = {
+            },
+            line_v_nudge = {
+            },
+            lines = {
+            },
+        },
+        br = {
+            h_offset = 2,
+            line_bar_height = {
+            },
+            line_bar_style = {
+                "rounded",
+            },
+            line_bar_type = {
+                "book_ticks",
+            },
+            line_font_face = {
+                "@family:ui",
+            },
+            line_font_size = {
+                13,
+            },
+            line_h_nudge = {
+            },
+            line_page_filter = {
+            },
+            line_style = {
+            },
+            line_uppercase = {
+            },
+            line_v_nudge = {
+                1,
+            },
+            lines = {
+                "%bar{v14}    %c / %t | ⌚ %K | ⇒ %l | %B %b | ⤠ %p | ⏳ %H | ⤻ %h",
+            },
+        },
+        tc = {
+            line_bar_height = {
+            },
+            line_bar_style = {
+            },
+            line_bar_type = {
+            },
+            line_font_face = {
+            },
+            line_font_size = {
+            },
+            line_h_nudge = {
+            },
+            line_page_filter = {
+            },
+            line_style = {
+            },
+            line_uppercase = {
+            },
+            line_v_nudge = {
+            },
+            lines = {
+                "",
+            },
+        },
+        tl = {
+            lines = {
+            },
+        },
+        tr = {
+            lines = {
+            },
+        },
+    },
+    progress_bars = {
+        {
+            chapter_ticks = "off",
+            colors = {
+                bg = 0,
+                border_thickness = 1,
+                fill = 0,
+            },
+            enabled = true,
+            height = 2,
+            margin_left = 19,
+            margin_right = 19,
+            margin_v = 38,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+    },
+    tick_height_pct = 80,
+    tick_width_multiplier = 3,
+}


### PR DESCRIPTION
**KOReader stock** — Mimics KOReader's built-in status bar — page, clock, chapter, battery, percent, time remaining

Submitted by **AndyHazz** via the bookends preset manager.

- Slug: `koreader-stock`
- File: [`presets/koreader-stock.lua`](../blob/submit/koreader-stock-tdrajc/presets/koreader-stock.lua)