### PR TITLE
Submission: Kobo by ReadinGadgets

### DIFF
--- a/presets/kobo.lua
+++ b/presets/kobo.lua
@@ -1,0 +1,290 @@
+-- Bookends preset: Kobo
+return {
+    author = "ReadinGadgets",
+    bar_colors = {
+        bg = 255,
+        tick_height_pct = 100,
+    },
+    defaults = {
+        font_scale = 100,
+        font_size = 14,
+        margin_bottom = 10,
+        margin_left = 18,
+        margin_right = 18,
+        margin_top = 10,
+        overlap_gap = 50,
+        truncation_priority = "sides",
+    },
+    description = "As close to Kobo",
+    name = "Kobo",
+    positions = {
+        bc = {
+            line_bar_height = {
+            },
+            line_bar_style = {
+            },
+            line_bar_type = {
+            },
+            line_bar_width = {
+            },
+            line_font_face = {
+            },
+            line_font_size = {
+                15,
+            },
+            line_h_nudge = {
+            },
+            line_page_filter = {
+            },
+            line_style = {
+                "bold",
+            },
+            line_uppercase = {
+                true,
+            },
+            line_v_nudge = {
+                -26,
+            },
+            lines = {
+                "%T{750}  ·  %c Of %t",
+            },
+        },
+        bl = {
+            disabled = true,
+            h_offset = 5,
+            line_font_face = {
+            },
+            line_font_size = {
+            },
+            line_h_nudge = {
+            },
+            line_page_filter = {
+            },
+            line_style = {
+            },
+            line_uppercase = {
+            },
+            line_v_nudge = {
+            },
+            lines = {
+                "%k",
+            },
+        },
+        br = {
+            line_bar_height = {
+            },
+            line_bar_style = {
+            },
+            line_bar_type = {
+            },
+            line_font_face = {
+            },
+            line_font_size = {
+            },
+            line_h_nudge = {
+            },
+            line_page_filter = {
+            },
+            line_style = {
+            },
+            line_uppercase = {
+            },
+            line_v_nudge = {
+            },
+            lines = {
+            },
+        },
+        tc = {
+            line_bar_height = {
+            },
+            line_bar_style = {
+            },
+            line_bar_type = {
+            },
+            line_bar_width = {
+            },
+            line_font_face = {
+            },
+            line_font_size = {
+                15,
+            },
+            line_h_nudge = {
+            },
+            line_page_filter = {
+            },
+            line_style = {
+                "bold",
+            },
+            line_uppercase = {
+                true,
+            },
+            line_v_nudge = {
+                15,
+            },
+            lines = {
+                "[if:format=EPUB]%C{720}  ·  %g Of %G[/if]",
+                "",
+            },
+        },
+        tl = {
+            disabled = true,
+            line_bar_height = {
+            },
+            line_bar_style = {
+            },
+            line_bar_type = {
+            },
+            line_bar_width = {
+            },
+            line_font_face = {
+            },
+            line_font_size = {
+                14,
+            },
+            line_h_nudge = {
+            },
+            line_page_filter = {
+            },
+            line_style = {
+            },
+            line_uppercase = {
+            },
+            line_v_nudge = {
+            },
+            lines = {
+                "%k",
+            },
+        },
+        tr = {
+            disabled = true,
+            line_bar_height = {
+            },
+            line_bar_style = {
+            },
+            line_bar_type = {
+            },
+            line_bar_width = {
+            },
+            line_font_face = {
+            },
+            line_font_size = {
+            },
+            line_h_nudge = {
+            },
+            line_page_filter = {
+            },
+            line_style = {
+            },
+            line_uppercase = {
+            },
+            line_v_nudge = {
+            },
+            lines = {
+                "%W [if:light=off][else]%f% [/if] [if:charging=yes]⚡%B[/if][if:batt<50]%b[/if]",
+            },
+        },
+    },
+    progress_bars = {
+        {
+            chapter_ticks = "level1",
+            enabled = false,
+            height = 10,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "level2",
+            colors = {
+                bg = {
+                    grey = 191,
+                },
+                fill = {
+                    grey = 0,
+                },
+                invert_read_ticks = false,
+                tick = 255,
+                track = 255,
+            },
+            enabled = true,
+            height = 5,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 15,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+    },
+    tick_height_pct = 100,
+    tick_width_multiplier = 2,
+}


### PR DESCRIPTION
**Kobo** — As close to Kobo

Submitted by **ReadinGadgets** via the bookends preset manager.

- Slug: `kobo`
- File: [`presets/kobo.lua`](../blob/submit/kobo-te01cx/presets/kobo.lua)