### PR TITLE
Update Placid Preset

### DIFF
--- a/presets/placid.lua
+++ b/presets/placid.lua
@@ -63,8 +63,8 @@ return {
             line_v_nudge = {
             },
             lines = {
-                "%book_pct ",
-                "%chap_pct",
+                "%book_pct ",
+                "%chap_pct ",
             },
         },
         br = {
@@ -91,8 +91,8 @@ return {
             line_v_nudge = {
             },
             lines = {
-                "⌛ %book_time_left",
-                "⏳ %chap_time_left",
+                " %book_time_left",
+                " %chap_time_left",
             },
         },
         tc = {

--- a/presets/placid.lua
+++ b/presets/placid.lua
@@ -15,8 +15,28 @@ return {
     name = "Placid",
     positions = {
         bc = {
+            line_bar_height = {
+            },
+            line_bar_style = {
+            },
+            line_bar_type = {
+            },
+            line_font_face = {
+            },
+            line_font_size = {
+            },
+            line_h_nudge = {
+            },
+            line_page_filter = {
+            },
+            line_style = {
+            },
+            line_uppercase = {
+            },
+            line_v_nudge = {
+            },
             lines = {
-                "Page %c of %t",
+                "%page_num of %page_count",
             },
         },
         bl = {
@@ -43,8 +63,8 @@ return {
             line_v_nudge = {
             },
             lines = {
-                "%p ",
-                "%P",
+                "%book_pct ",
+                "%chap_pct",
             },
         },
         br = {
@@ -71,22 +91,37 @@ return {
             line_v_nudge = {
             },
             lines = {
-                "⌛ %H",
-                "⏳ %h",
+                "⌛ %book_time_left",
+                "⏳ %chap_time_left",
             },
         },
         tc = {
+            line_bar_height = {
+            },
+            line_bar_style = {
+            },
+            line_bar_type = {
+            },
+            line_font_face = {
+            },
+            line_font_size = {
+            },
+            line_h_nudge = {
+            },
             line_page_filter = {
                 "odd",
                 "even",
             },
             line_style = {
                 "italic",
-                "regular",
+            },
+            line_uppercase = {
+            },
+            line_v_nudge = {
             },
             lines = {
-                "%T",
-                "[if:series]%S - [/if][i]%A[/i]",
+                "%title - %chap_title",
+                "[if:series]%series - [/if][i]%author[/i]",
             },
         },
         tl = {
@@ -113,13 +148,13 @@ return {
             line_v_nudge = {
             },
             lines = {
-                "%k",
-                "%a %d",
+                "%time_12h",
+                "%weekday_short %date",
             },
         },
         tr = {
             lines = {
-                "%W %B %b",
+                "%wifi %batt_icon %batt",
             },
         },
     },
@@ -213,6 +248,7 @@ return {
             v_anchor = "bottom",
         },
     },
+    schema_version = 5,
     text_color = {
         grey = 64,
     },


### PR DESCRIPTION
Thank you for your hard work on this plugin!
I submitted the "Placid" preset a couple of days ago. Shortly thereafter, I made a few tweaks to my local copy which I think greatly improve the preset so I've decided to submit them as a PR.

- The chapter title is now included alongside the book title on alternating pages
- The page counter has been shortened from "Page X of XX" to "X of XX"
- The icons used on the bottom bar to represent progress throughout book/chapter and time left in book/chapter have been changed to better reflect their actual meaning.