### PR TITLE
Submission: PDF preset by AndyHazz

### DIFF
--- a/presets/pdf-preset.lua
+++ b/presets/pdf-preset.lua
@@ -1,0 +1,243 @@
+-- Bookends preset: PDF preset
+return {
+    author = "AndyHazz",
+    background_color = {
+        grey = 0,
+    },
+    bar_colors = {
+        bg = {
+            grey = 51,
+        },
+        tick = {
+            grey = 252,
+        },
+        tick_height_pct = 100,
+        unread_height_pct = 50,
+    },
+    defaults = {
+        font_scale = 70,
+        font_size = 14,
+        margin_bottom = 0,
+        margin_left = 18,
+        margin_right = 18,
+        margin_top = 10,
+        overlap_gap = 50,
+        truncation_priority = "sides",
+    },
+    description = "Made for CBZ or PDF with background fill, white on black",
+    name = "PDF preset",
+    positions = {
+        bc = {
+            line_bar_height = {
+            },
+            line_bar_style = {
+            },
+            line_bar_type = {
+            },
+            line_font_face = {
+            },
+            line_font_size = {
+                17,
+            },
+            line_h_nudge = {
+            },
+            line_page_filter = {
+            },
+            line_style = {
+                "bold",
+            },
+            line_uppercase = {
+            },
+            line_v_nudge = {
+            },
+            lines = {
+                "%book_pct%page_num/%page_count",
+            },
+        },
+        bl = {
+            line_bar_height = {
+            },
+            line_bar_style = {
+                "wavy",
+            },
+            line_bar_type = {
+                "book",
+            },
+            line_font_face = {
+            },
+            line_font_size = {
+                17,
+            },
+            line_h_nudge = {
+            },
+            line_page_filter = {
+            },
+            line_style = {
+                "bold",
+            },
+            line_uppercase = {
+            },
+            line_v_nudge = {
+            },
+            lines = {
+                "%chap_time_left%chap_pages_left",
+            },
+        },
+        br = {
+            line_bar_height = {
+            },
+            line_bar_style = {
+            },
+            line_bar_type = {
+            },
+            line_font_face = {
+            },
+            line_font_size = {
+                17,
+            },
+            line_h_nudge = {
+            },
+            line_page_filter = {
+            },
+            line_style = {
+                "bold",
+            },
+            line_uppercase = {
+            },
+            line_v_nudge = {
+            },
+            lines = {
+                "%wifi %batt_icon%batt  %time_12h",
+            },
+        },
+        tc = {
+            disabled = true,
+            line_bar_height = {
+            },
+            line_bar_style = {
+            },
+            line_bar_type = {
+            },
+            line_font_face = {
+            },
+            line_font_size = {
+            },
+            line_h_nudge = {
+            },
+            line_page_filter = {
+            },
+            line_style = {
+            },
+            line_uppercase = {
+            },
+            line_v_nudge = {
+            },
+            lines = {
+            },
+        },
+        tl = {
+            lines = {
+            },
+        },
+        tr = {
+            lines = {
+            },
+        },
+    },
+    progress_bars = {
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+    },
+    schema_version = 5,
+    text_color = {
+        grey = 252,
+    },
+    tick_height_pct = 100,
+    tick_width_multiplier = 5,
+}


### PR DESCRIPTION
**PDF preset** — Made for CBZ or PDF with background fill, white on black

Submitted by **AndyHazz** via the bookends preset manager.

- Slug: `pdf-preset`
- File: [`presets/pdf-preset.lua`](../blob/submit/pdf-preset-teq6t7/presets/pdf-preset.lua)