### PR TITLE
Submission: Manga Minimal by fatcats55

### DIFF
--- a/presets/manga-minimal.lua
+++ b/presets/manga-minimal.lua
@@ -27,7 +27,7 @@ return {
         overlap_gap = 50,
         truncation_priority = "center",
     },
-    description = "Minimal settings for manga reading. Includes pages, tine left in book, mibi progress bar, clock, wifi, and battery %.",
+    description = "Minimal settings for manga reading. Includes pages, time left in book, mini progress bar, clock, wifi, and battery %.",
     name = "Manga Minimal",
     positions = {
         bc = {

--- a/presets/manga-minimal.lua
+++ b/presets/manga-minimal.lua
@@ -1,0 +1,275 @@
+-- Bookends preset: Manga Minimal
+return {
+    author = "fatcats55",
+    bar_colors = {
+        bg = {
+            grey = 127,
+        },
+        border = {
+            grey = 51,
+        },
+        fill = {
+            grey = 229,
+        },
+        tick = {
+            grey = 252,
+        },
+        tick_height_pct = 100,
+        unread_height_pct = 50,
+    },
+    defaults = {
+        font_scale = 100,
+        font_size = 14,
+        margin_bottom = 0,
+        margin_left = 15,
+        margin_right = 15,
+        margin_top = 2,
+        overlap_gap = 50,
+        truncation_priority = "center",
+    },
+    description = "Minimal settings for manga reading. Includes pages, tine left in book, mibi progress bar, clock, wifi, and battery %.",
+    name = "Manga Minimal",
+    positions = {
+        bc = {
+            line_bar_height = {
+            },
+            line_bar_style = {
+            },
+            line_bar_type = {
+            },
+            line_font_face = {
+            },
+            line_font_size = {
+            },
+            line_h_nudge = {
+            },
+            line_page_filter = {
+            },
+            line_style = {
+            },
+            line_uppercase = {
+            },
+            line_v_nudge = {
+            },
+            lines = {
+            },
+        },
+        bl = {
+            line_bar_height = {
+            },
+            line_bar_style = {
+                "rounded",
+            },
+            line_bar_type = {
+                "book",
+            },
+            line_font_face = {
+            },
+            line_font_size = {
+            },
+            line_h_nudge = {
+            },
+            line_page_filter = {
+            },
+            line_style = {
+            },
+            line_uppercase = {
+            },
+            line_v_nudge = {
+            },
+            lines = {
+                "%page_num of %page_count  %chap_time_left   %bar{300v14}",
+            },
+        },
+        br = {
+            line_bar_height = {
+            },
+            line_bar_style = {
+            },
+            line_bar_type = {
+            },
+            line_font_face = {
+            },
+            line_font_size = {
+            },
+            line_h_nudge = {
+            },
+            line_page_filter = {
+            },
+            line_style = {
+            },
+            line_uppercase = {
+            },
+            line_v_nudge = {
+            },
+            lines = {
+            },
+        },
+        tc = {
+            disabled = true,
+            line_bar_height = {
+            },
+            line_bar_style = {
+            },
+            line_bar_type = {
+            },
+            line_font_face = {
+            },
+            line_font_size = {
+            },
+            line_h_nudge = {
+            },
+            line_page_filter = {
+            },
+            line_style = {
+            },
+            line_uppercase = {
+            },
+            line_v_nudge = {
+            },
+            lines = {
+            },
+        },
+        tl = {
+            line_bar_height = {
+            },
+            line_bar_style = {
+            },
+            line_bar_type = {
+            },
+            line_font_face = {
+            },
+            line_font_size = {
+            },
+            line_h_nudge = {
+            },
+            line_style = {
+            },
+            line_uppercase = {
+            },
+            line_v_nudge = {
+            },
+            lines = {
+                "%time_12h",
+            },
+        },
+        tr = {
+            line_bar_height = {
+            },
+            line_bar_style = {
+            },
+            line_bar_type = {
+            },
+            line_font_face = {
+            },
+            line_font_size = {
+            },
+            line_h_nudge = {
+            },
+            line_page_filter = {
+            },
+            line_style = {
+            },
+            line_uppercase = {
+            },
+            line_v_nudge = {
+            },
+            lines = {
+                "%wifi %batt_icon%batt",
+            },
+        },
+    },
+    progress_bars = {
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+    },
+    schema_version = 5,
+    tick_height_pct = 100,
+    tick_width_multiplier = 5,
+}


### PR DESCRIPTION
**Manga Minimal** — Minimal settings for manga reading. Includes pages, tine left in book, mibi progress bar, clock, wifi, and battery %.

Submitted by **fatcats55** via the bookends preset manager.

- Slug: `manga-minimal`
- File: [`presets/manga-minimal.lua`](../blob/submit/manga-minimal-teyop7/presets/manga-minimal.lua)