### PR TITLE
Submission: Book & Chapter Info by rot-and-read

### DIFF
--- a/presets/book-chapter-info.lua
+++ b/presets/book-chapter-info.lua
@@ -1,0 +1,303 @@
+-- Bookends preset: Book & Chapter Info
+return {
+    author = "rot-and-read",
+    defaults = {
+        font_scale = 100,
+        font_size = 14,
+        margin_bottom = 25,
+        margin_left = 18,
+        margin_right = 18,
+        margin_top = 10,
+        overlap_gap = 50,
+        truncation_priority = "sides",
+    },
+    description = "See book & chapter information at a glance. Includes two progress bars and misc book/chap info.",
+    name = "Book & Chapter Info",
+    positions = {
+        bc = {
+            line_bar_chapter_ticks = {
+            },
+            line_bar_colors = {
+            },
+            line_bar_direction = {
+            },
+            line_bar_height = {
+            },
+            line_bar_style = {
+            },
+            line_bar_type = {
+            },
+            line_bar_unread_height = {
+            },
+            line_font_face = {
+            },
+            line_font_size = {
+            },
+            line_h_nudge = {
+            },
+            line_page_filter = {
+            },
+            line_style = {
+            },
+            line_uppercase = {
+            },
+            line_v_nudge = {
+                17,
+            },
+            lines = {
+                "[b]%book_pct[/b]|⏳%book_time_left| [i]%page_num / %page_count[/i] [b]•[/b]  [i]%chap_num / %chap_count[/i]|⏳ %chap_time_left|[b]%chap_pct[/b]",
+            },
+            v_offset = 7,
+        },
+        bl = {
+            disabled = true,
+            line_bar_height = {
+            },
+            line_bar_style = {
+            },
+            line_bar_type = {
+            },
+            line_font_face = {
+            },
+            line_font_size = {
+            },
+            line_h_nudge = {
+                10,
+            },
+            line_page_filter = {
+            },
+            line_style = {
+                "bold",
+            },
+            line_uppercase = {
+            },
+            line_v_nudge = {
+                11,
+            },
+            lines = {
+                "%book_pct",
+            },
+        },
+        br = {
+            disabled = true,
+            line_bar_height = {
+            },
+            line_bar_style = {
+            },
+            line_bar_type = {
+                "book",
+            },
+            line_font_face = {
+            },
+            line_font_size = {
+            },
+            line_h_nudge = {
+                -15,
+            },
+            line_page_filter = {
+            },
+            line_style = {
+                "bold",
+            },
+            line_uppercase = {
+            },
+            line_v_nudge = {
+                11,
+            },
+            lines = {
+                "%chap_pct",
+            },
+        },
+        tc = {
+            line_bar_height = {
+            },
+            line_bar_style = {
+            },
+            line_bar_type = {
+            },
+            line_font_face = {
+            },
+            line_font_size = {
+            },
+            line_h_nudge = {
+            },
+            line_page_filter = {
+            },
+            line_style = {
+                "italic",
+            },
+            line_uppercase = {
+            },
+            line_v_nudge = {
+            },
+            lines = {
+                "%chap_title",
+                "",
+            },
+        },
+        tl = {
+            line_bar_height = {
+            },
+            line_bar_style = {
+            },
+            line_bar_type = {
+            },
+            line_font_face = {
+            },
+            line_font_size = {
+            },
+            line_h_nudge = {
+            },
+            line_page_filter = {
+            },
+            line_style = {
+                "bold",
+            },
+            line_uppercase = {
+            },
+            line_v_nudge = {
+            },
+            lines = {
+                "%time_12h",
+            },
+        },
+        tr = {
+            line_bar_height = {
+            },
+            line_bar_style = {
+            },
+            line_bar_type = {
+            },
+            line_font_face = {
+            },
+            line_font_size = {
+            },
+            line_h_nudge = {
+            },
+            line_page_filter = {
+            },
+            line_style = {
+            },
+            line_uppercase = {
+            },
+            line_v_nudge = {
+            },
+            lines = {
+                "%batt_icon[b]%batt[/b]",
+            },
+        },
+    },
+    progress_bars = {
+        {
+            chapter_ticks = "level1",
+            colors = {
+                bg = {
+                    grey = 178,
+                },
+                fill = {
+                    grey = 25,
+                },
+                invert = 255,
+                invert_read_ticks = false,
+                tick_height_pct = 100,
+                tick_width_multiplier = 2,
+            },
+            enabled = true,
+            height = 5,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            colors = {
+                bg = {
+                    grey = 178,
+                },
+                fill = {
+                    grey = 25,
+                },
+                tick_height_pct = 100,
+                tick_width_multiplier = 2,
+            },
+            enabled = true,
+            height = 5,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 5,
+            style = "solid",
+            type = "chapter",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+    },
+    schema_version = 5,
+}


### PR DESCRIPTION
**Book & Chapter Info** — See book & chapter information at a glance. Includes two progress bars and misc book/chap info.

Submitted by **rot-and-read** via the bookends preset manager.

- Slug: `book-chapter-info`
- File: [`presets/book-chapter-info.lua`](../blob/submit/book-chapter-info-tg21qb/presets/book-chapter-info.lua)