### PR TITLE
Submission: 2-row~header by phyvealive

### DIFF
--- a/presets/2-row-header.lua
+++ b/presets/2-row-header.lua
@@ -1,0 +1,271 @@
+-- Bookends preset: 2-row~header
+return {
+    author = "phyvealive",
+    defaults = {
+        font_scale = 100,
+        font_size = 20,
+        margin_bottom = 10,
+        margin_left = 18,
+        margin_right = 18,
+        margin_top = 10,
+        overlap_gap = 40,
+        truncation_priority = "center",
+    },
+    description = "Header 1~Time, Title, Author, battery. Header 2~Day, 3 layer chapter display, pages, WiFi.",
+    name = "2-row~header",
+    positions = {
+        bc = {
+            line_bar_chapter_ticks = {
+            },
+            line_bar_colors = {
+            },
+            line_bar_direction = {
+            },
+            line_bar_height = {
+            },
+            line_bar_style = {
+            },
+            line_bar_type = {
+            },
+            line_bar_unread_height = {
+            },
+            line_font_face = {
+            },
+            line_font_size = {
+                20,
+            },
+            line_h_nudge = {
+            },
+            line_page_filter = {
+            },
+            line_style = {
+                "bold",
+            },
+            line_uppercase = {
+            },
+            line_v_nudge = {
+            },
+            lines = {
+                "—— page %page_num of %page_count ——",
+            },
+        },
+        bl = {
+            lines = {
+            },
+        },
+        br = {
+            lines = {
+            },
+        },
+        tc = {
+            line_bar_chapter_ticks = {
+            },
+            line_bar_colors = {
+            },
+            line_bar_direction = {
+            },
+            line_bar_height = {
+                [2] = 6,
+            },
+            line_bar_style = {
+                [2] = "radial_hollow",
+            },
+            line_bar_type = {
+            },
+            line_bar_unread_height = {
+                [2] = 0,
+            },
+            line_font_face = {
+            },
+            line_font_size = {
+                18,
+                18,
+            },
+            line_h_nudge = {
+            },
+            line_page_filter = {
+            },
+            line_style = {
+                "bolditalic",
+                "bold",
+            },
+            line_uppercase = {
+            },
+            line_v_nudge = {
+            },
+            lines = {
+                "[if:page=odd]%title[else]%author[/if]",
+                "page %chap_read of %chap_pages[if:chap_title_3]%chap_title[/if]  [if:chap_title_1] %chap_title_1[/if] [if:chap_title_2]%chap_title_2[/if]",
+            },
+        },
+        tl = {
+            line_bar_chapter_ticks = {
+            },
+            line_bar_colors = {
+            },
+            line_bar_direction = {
+            },
+            line_bar_height = {
+            },
+            line_bar_style = {
+            },
+            line_bar_type = {
+            },
+            line_bar_unread_height = {
+            },
+            line_font_face = {
+            },
+            line_font_size = {
+            },
+            line_h_nudge = {
+            },
+            line_page_filter = {
+            },
+            line_style = {
+                "bold",
+            },
+            line_uppercase = {
+            },
+            line_v_nudge = {
+            },
+            lines = {
+                "%time_12h",
+                "%weekday",
+            },
+        },
+        tr = {
+            line_bar_chapter_ticks = {
+            },
+            line_bar_colors = {
+            },
+            line_bar_direction = {
+            },
+            line_bar_height = {
+            },
+            line_bar_style = {
+            },
+            line_bar_type = {
+            },
+            line_bar_unread_height = {
+            },
+            line_font_face = {
+            },
+            line_font_size = {
+            },
+            line_h_nudge = {
+            },
+            line_page_filter = {
+            },
+            line_style = {
+                "bold",
+            },
+            line_uppercase = {
+            },
+            line_v_nudge = {
+            },
+            lines = {
+                "%batt",
+                "[if:wifi=on] [/if][if:wifi=off] [/if]",
+            },
+        },
+    },
+    progress_bars = {
+        {
+            chapter_ticks = "off",
+            enabled = true,
+            height = 5,
+            margin_left = 1,
+            margin_right = 0,
+            margin_v = 68,
+            style = "solid",
+            type = "book",
+            unread_height = 1,
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = true,
+            height = 5,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 108,
+            style = "solid",
+            type = "chapter",
+            unread_height = 2,
+            v_anchor = "top",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+    },
+    schema_version = 5,
+    symbol_color = {
+        hex = "#228B22",
+    },
+    text_color = {
+        hex = "#228B22",
+    },
+}


### PR DESCRIPTION
**2-row~header** — Header 1~Time, Title, Author, battery. Header 2~Day, 3 layer chapter display, pages, WiFi.

Submitted by **phyvealive** via the bookends preset manager.

- Slug: `2-row-header`
- File: [`presets/2-row-header.lua`](../blob/submit/2-row-header-thbubv/presets/2-row-header.lua)