### PR TITLE
Submission: booklike plus percent/progress bar by mothsphere

### DIFF
--- a/presets/booklike-plus-percent-progress-bar.lua
+++ b/presets/booklike-plus-percent-progress-bar.lua
@@ -1,0 +1,202 @@
+-- Bookends preset: booklike plus percent/progress bar
+return {
+    author = "mothsphere",
+    defaults = {
+        font_scale = 100,
+        font_size = 12,
+        margin_bottom = 10,
+        margin_left = 18,
+        margin_right = 18,
+        margin_top = 10,
+        overlap_gap = 50,
+        truncation_priority = "sides",
+    },
+    description = "low profile, book/chap titles alternate except blank on first page of chap. ",
+    name = "booklike plus percent/progress bar",
+    positions = {
+        bc = {
+            line_bar_chapter_ticks = {
+            },
+            line_bar_colors = {
+            },
+            line_bar_direction = {
+            },
+            line_bar_height = {
+                15,
+            },
+            line_bar_markers = {
+            },
+            line_bar_style = {
+                "solid",
+            },
+            line_bar_type = {
+                "book",
+            },
+            line_bar_unread_height = {
+            },
+            line_font_face = {
+            },
+            line_font_size = {
+            },
+            line_h_nudge = {
+            },
+            line_page_filter = {
+            },
+            line_style = {
+            },
+            line_uppercase = {
+            },
+            line_v_nudge = {
+                7,
+            },
+            lines = {
+                "   %page_num/%page_count  %bar  %book_pct   ",
+            },
+        },
+        bl = {
+            lines = {
+            },
+        },
+        br = {
+            lines = {
+            },
+        },
+        tc = {
+            line_bar_chapter_ticks = {
+            },
+            line_bar_colors = {
+            },
+            line_bar_direction = {
+            },
+            line_bar_height = {
+            },
+            line_bar_markers = {
+            },
+            line_bar_style = {
+            },
+            line_bar_type = {
+            },
+            line_bar_unread_height = {
+            },
+            line_font_face = {
+            },
+            line_font_size = {
+                13,
+            },
+            line_h_nudge = {
+            },
+            line_page_filter = {
+            },
+            line_style = {
+                "italic",
+            },
+            line_uppercase = {
+                true,
+            },
+            line_v_nudge = {
+            },
+            lines = {
+                "[if:chap_pct=0] [else][if:page=odd]%title[else]%chap_title[/if][/if]",
+            },
+        },
+        tl = {
+            lines = {
+            },
+        },
+        tr = {
+            lines = {
+            },
+        },
+    },
+    progress_bars = {
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+    },
+    schema_version = 5,
+}


### PR DESCRIPTION
**booklike plus percent/progress bar** — low profile, book/chap titles alternate except blank on first page of chap. 

Submitted by **mothsphere** via the bookends preset manager.

- Slug: `booklike-plus-percent-progress-bar`
- File: [`presets/booklike-plus-percent-progress-bar.lua`](../blob/submit/booklike-plus-percent-progress-bar-thfskb/presets/booklike-plus-percent-progress-bar.lua)