### PR TITLE
Submission: Nat’s Kindle+Kobo Inspired Bookends by nyataliefyi

### DIFF
--- a/presets/nat-s-kindle-kobo-inspired-bookends.lua
+++ b/presets/nat-s-kindle-kobo-inspired-bookends.lua
@@ -1,0 +1,274 @@
+-- Bookends preset: Nat’s Kindle+Kobo Inspired Bookends
+return {
+    author = "nyataliefyi",
+    defaults = {
+        font_scale = 100,
+        font_size = 14,
+        margin_bottom = 25,
+        margin_left = 18,
+        margin_right = 18,
+        margin_top = 10,
+        overlap_gap = 50,
+        truncation_priority = "center",
+    },
+    description = "A mix of Kindle and Kobo UI in my own take.",
+    name = "Nat’s Kindle+Kobo Inspired Bookends",
+    positions = {
+        bc = {
+            line_bar_height = {
+            },
+            line_bar_style = {
+            },
+            line_bar_type = {
+            },
+            line_font_face = {
+            },
+            line_font_size = {
+            },
+            line_h_nudge = {
+            },
+            line_page_filter = {
+            },
+            line_style = {
+                "bold",
+            },
+            line_uppercase = {
+            },
+            line_v_nudge = {
+                3,
+            },
+            lines = {
+                "Page %page_num / %page_count ⋅ Ch. Page %chap_read / %chap_pages",
+            },
+            v_offset = 4,
+        },
+        bl = {
+            line_bar_height = {
+            },
+            line_bar_style = {
+            },
+            line_bar_type = {
+            },
+            line_font_face = {
+            },
+            line_font_size = {
+            },
+            line_h_nudge = {
+                30,
+            },
+            line_page_filter = {
+            },
+            line_style = {
+                "bold",
+            },
+            line_uppercase = {
+            },
+            line_v_nudge = {
+            },
+            lines = {
+                "%time",
+            },
+        },
+        br = {
+            line_bar_height = {
+            },
+            line_bar_style = {
+            },
+            line_bar_type = {
+            },
+            line_font_face = {
+            },
+            line_font_size = {
+            },
+            line_h_nudge = {
+                -30,
+            },
+            line_page_filter = {
+            },
+            line_style = {
+                "bold",
+            },
+            line_uppercase = {
+            },
+            line_v_nudge = {
+            },
+            lines = {
+                "%book_pct ⋅ %batt_icon %batt",
+            },
+        },
+        tc = {
+            line_bar_height = {
+            },
+            line_bar_style = {
+            },
+            line_bar_type = {
+            },
+            line_font_face = {
+            },
+            line_font_size = {
+                13,
+            },
+            line_h_nudge = {
+            },
+            line_page_filter = {
+            },
+            line_style = {
+            },
+            line_uppercase = {
+            },
+            line_v_nudge = {
+            },
+            lines = {
+                "%title ⋅ %chap_title",
+            },
+        },
+        tl = {
+            disabled = true,
+            line_bar_height = {
+            },
+            line_bar_style = {
+            },
+            line_bar_type = {
+            },
+            line_font_face = {
+            },
+            line_font_size = {
+            },
+            line_h_nudge = {
+            },
+            line_page_filter = {
+            },
+            line_style = {
+            },
+            line_uppercase = {
+            },
+            line_v_nudge = {
+            },
+            lines = {
+                "",
+            },
+        },
+        tr = {
+            disabled = true,
+            line_bar_height = {
+            },
+            line_bar_style = {
+            },
+            line_bar_type = {
+            },
+            line_font_face = {
+            },
+            line_font_size = {
+                15,
+            },
+            line_h_nudge = {
+                -19,
+            },
+            line_page_filter = {
+            },
+            line_style = {
+                "bold",
+            },
+            line_uppercase = {
+            },
+            line_v_nudge = {
+                4,
+            },
+            lines = {
+                "%batt %batt_icon",
+            },
+        },
+    },
+    progress_bars = {
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+    },
+    schema_version = 5,
+    tick_width_multiplier = 2,
+}


### PR DESCRIPTION
**Nat’s Kindle+Kobo Inspired Bookends** — A mix of Kindle and Kobo UI in my own take.

Submitted by **nyataliefyi** via the bookends preset manager.

- Slug: `nat-s-kindle-kobo-inspired-bookends`
- File: [`presets/nat-s-kindle-kobo-inspired-bookends.lua`](../blob/submit/nat-s-kindle-kobo-inspired-bookends-thinh4/presets/nat-s-kindle-kobo-inspired-bookends.lua)