### PR TITLE
Submission: Kobo Dupe by jayqism

### DIFF
--- a/presets/kobo-dupe.lua
+++ b/presets/kobo-dupe.lua
@@ -1,0 +1,327 @@
+-- Bookends preset: Kobo Dupe
+return {
+    author = "jayqism",
+    defaults = {
+        font_scale = 100,
+        font_size = 14,
+        margin_bottom = 10,
+        margin_left = 18,
+        margin_right = 18,
+        margin_top = 10,
+        overlap_gap = 50,
+        truncation_priority = "sides",
+    },
+    description = "Dupe of Kobo’s layout with minimal additional information.",
+    name = "Kobo Dupe",
+    positions = {
+        bc = {
+            line_bar_chapter_ticks = {
+            },
+            line_bar_colors = {
+            },
+            line_bar_direction = {
+            },
+            line_bar_height = {
+            },
+            line_bar_style = {
+            },
+            line_bar_type = {
+            },
+            line_bar_unread_height = {
+            },
+            line_bar_width = {
+            },
+            line_font_face = {
+            },
+            line_font_size = {
+                14,
+            },
+            line_h_nudge = {
+            },
+            line_page_filter = {
+            },
+            line_style = {
+            },
+            line_uppercase = {
+                true,
+            },
+            line_v_nudge = {
+                -5,
+            },
+            lines = {
+                "%title · %book_pct read",
+            },
+        },
+        bl = {
+            disabled = true,
+            h_offset = 5,
+            line_font_face = {
+            },
+            line_font_size = {
+            },
+            line_h_nudge = {
+            },
+            line_page_filter = {
+            },
+            line_style = {
+            },
+            line_uppercase = {
+            },
+            line_v_nudge = {
+            },
+            lines = {
+                "%time_12h",
+            },
+        },
+        br = {
+            disabled = true,
+            line_bar_chapter_ticks = {
+            },
+            line_bar_colors = {
+            },
+            line_bar_direction = {
+            },
+            line_bar_height = {
+            },
+            line_bar_style = {
+            },
+            line_bar_type = {
+            },
+            line_bar_unread_height = {
+            },
+            line_font_face = {
+            },
+            line_font_size = {
+            },
+            line_h_nudge = {
+            },
+            line_page_filter = {
+            },
+            line_style = {
+            },
+            line_uppercase = {
+            },
+            line_v_nudge = {
+            },
+            lines = {
+            },
+        },
+        tc = {
+            line_bar_chapter_ticks = {
+            },
+            line_bar_colors = {
+            },
+            line_bar_direction = {
+            },
+            line_bar_height = {
+            },
+            line_bar_style = {
+            },
+            line_bar_type = {
+            },
+            line_bar_unread_height = {
+            },
+            line_bar_width = {
+            },
+            line_font_face = {
+            },
+            line_font_size = {
+                14,
+            },
+            line_h_nudge = {
+            },
+            line_page_filter = {
+            },
+            line_style = {
+            },
+            line_uppercase = {
+                true,
+            },
+            line_v_nudge = {
+                3,
+            },
+            lines = {
+                "[if:format=EPUB][if:chap_title]%chap_title{720} · %chap_read Of %chap_pages[/if][/if]",
+                "",
+            },
+        },
+        tl = {
+            line_bar_chapter_ticks = {
+            },
+            line_bar_colors = {
+            },
+            line_bar_direction = {
+            },
+            line_bar_height = {
+            },
+            line_bar_style = {
+            },
+            line_bar_type = {
+            },
+            line_bar_unread_height = {
+            },
+            line_bar_width = {
+            },
+            line_font_face = {
+            },
+            line_font_size = {
+                14,
+            },
+            line_h_nudge = {
+                5,
+            },
+            line_page_filter = {
+            },
+            line_style = {
+            },
+            line_uppercase = {
+            },
+            line_v_nudge = {
+                3,
+            },
+            lines = {
+                "%time",
+            },
+        },
+        tr = {
+            line_bar_chapter_ticks = {
+            },
+            line_bar_colors = {
+            },
+            line_bar_direction = {
+            },
+            line_bar_height = {
+            },
+            line_bar_style = {
+            },
+            line_bar_type = {
+            },
+            line_bar_unread_height = {
+            },
+            line_bar_width = {
+            },
+            line_font_face = {
+            },
+            line_font_size = {
+            },
+            line_h_nudge = {
+                -5,
+            },
+            line_page_filter = {
+            },
+            line_style = {
+            },
+            line_uppercase = {
+            },
+            line_v_nudge = {
+                3,
+            },
+            lines = {
+                "[if:wifi=on]%wifi[/if] %batt_icon%batt",
+            },
+        },
+    },
+    progress_bars = {
+        {
+            chapter_ticks = "level1",
+            enabled = false,
+            height = 10,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "level2",
+            colors = {
+                bg = {
+                    grey = 191,
+                },
+                fill = {
+                    grey = 0,
+                },
+                invert_read_ticks = false,
+                tick = 255,
+                track = 255,
+            },
+            enabled = true,
+            height = 7,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 4,
+            style = "solid",
+            type = "book",
+            unread_height = 5,
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+    },
+    schema_version = 5,
+}


### PR DESCRIPTION
**Kobo Dupe** — Dupe of Kobo’s layout with minimal additional information.

Submitted by **jayqism** via the bookends preset manager.

- Slug: `kobo-dupe`
- File: [`presets/kobo-dupe.lua`](../blob/submit/kobo-dupe-ti2w79/presets/kobo-dupe.lua)