### PR TITLE
Submission: Balanced Color+ by Zork

### DIFF
--- a/presets/balanced-color.lua
+++ b/presets/balanced-color.lua
@@ -1,0 +1,379 @@
+-- Bookends preset: Balanced Color+
+return {
+    author = "Zork",
+    defaults = {
+        font_scale = 100,
+        font_size = 14,
+        margin_bottom = 50,
+        margin_left = 30,
+        margin_right = 30,
+        margin_top = 20,
+        overlap_gap = 50,
+        truncation_priority = "center",
+    },
+    description = "Clean and informative.",
+    name = "Balanced Color+",
+    positions = {
+        bc = {
+            line_bar_chapter_ticks = {
+            },
+            line_bar_colors = {
+            },
+            line_bar_direction = {
+            },
+            line_bar_height = {
+            },
+            line_bar_markers = {
+            },
+            line_bar_style = {
+            },
+            line_bar_type = {
+            },
+            line_bar_unread_height = {
+            },
+            line_font_face = {
+            },
+            line_font_size = {
+            },
+            line_h_nudge = {
+            },
+            line_page_filter = {
+            },
+            line_style = {
+                "italic",
+            },
+            line_uppercase = {
+            },
+            line_v_nudge = {
+                33,
+            },
+            lines = {
+                "— %page_num of %page_count —",
+            },
+        },
+        bl = {
+            line_bar_chapter_ticks = {
+            },
+            line_bar_colors = {
+                {
+                    bg = {
+                        hex = "#98FB98",
+                    },
+                    border = {
+                        hex = "#98FB98",
+                    },
+                    fill = {
+                        hex = "#228B22",
+                    },
+                },
+            },
+            line_bar_direction = {
+            },
+            line_bar_height = {
+                11,
+            },
+            line_bar_markers = {
+                {
+                },
+            },
+            line_bar_style = {
+                "rounded",
+            },
+            line_bar_type = {
+            },
+            line_bar_unread_height = {
+            },
+            line_font_face = {
+            },
+            line_font_size = {
+                15,
+            },
+            line_h_nudge = {
+                6,
+            },
+            line_page_filter = {
+            },
+            line_style = {
+            },
+            line_uppercase = {
+            },
+            line_v_nudge = {
+                39,
+            },
+            lines = {
+                "%bar",
+            },
+        },
+        br = {
+            line_bar_chapter_ticks = {
+            },
+            line_bar_colors = {
+            },
+            line_bar_direction = {
+            },
+            line_bar_height = {
+            },
+            line_bar_markers = {
+            },
+            line_bar_style = {
+            },
+            line_bar_type = {
+            },
+            line_bar_unread_height = {
+            },
+            line_font_face = {
+                [2] = "@family:ui",
+            },
+            line_font_size = {
+                12,
+                10,
+            },
+            line_h_nudge = {
+                15,
+                -54,
+            },
+            line_page_filter = {
+            },
+            line_style = {
+                "italic",
+                "italic",
+            },
+            line_uppercase = {
+            },
+            line_v_nudge = {
+                70,
+                28,
+            },
+            lines = {
+                "%book_pct",
+                "%chap_title_2",
+            },
+        },
+        tc = {
+            line_bar_chapter_ticks = {
+            },
+            line_bar_colors = {
+            },
+            line_bar_direction = {
+            },
+            line_bar_height = {
+            },
+            line_bar_markers = {
+            },
+            line_bar_style = {
+            },
+            line_bar_type = {
+            },
+            line_bar_unread_height = {
+            },
+            line_font_face = {
+            },
+            line_font_size = {
+            },
+            line_h_nudge = {
+            },
+            line_page_filter = {
+            },
+            line_style = {
+                "italic",
+            },
+            line_uppercase = {
+            },
+            line_v_nudge = {
+                -21,
+            },
+            lines = {
+                "%time_24h",
+            },
+        },
+        tl = {
+            line_bar_chapter_ticks = {
+            },
+            line_bar_colors = {
+            },
+            line_bar_direction = {
+            },
+            line_bar_height = {
+            },
+            line_bar_markers = {
+            },
+            line_bar_style = {
+            },
+            line_bar_type = {
+            },
+            line_bar_unread_height = {
+            },
+            line_font_face = {
+            },
+            line_font_size = {
+                13,
+            },
+            line_h_nudge = {
+            },
+            line_page_filter = {
+            },
+            line_style = {
+                "italic",
+            },
+            line_uppercase = {
+            },
+            line_v_nudge = {
+                -20,
+            },
+            lines = {
+                " %title",
+            },
+        },
+        tr = {
+            line_bar_chapter_ticks = {
+            },
+            line_bar_colors = {
+            },
+            line_bar_direction = {
+            },
+            line_bar_height = {
+            },
+            line_bar_markers = {
+            },
+            line_bar_style = {
+            },
+            line_bar_type = {
+            },
+            line_bar_unread_height = {
+            },
+            line_font_face = {
+            },
+            line_font_size = {
+            },
+            line_h_nudge = {
+            },
+            line_page_filter = {
+            },
+            line_style = {
+                "italic",
+            },
+            line_uppercase = {
+            },
+            line_v_nudge = {
+                -20,
+            },
+            lines = {
+                "[if:wifi=on]%wifi[/if][if:charging=yes]⚡[/if] %batt_icon%batt",
+            },
+        },
+    },
+    progress_bars = {
+        {
+            chapter_ticks = "off",
+            colors = {
+                bg = {
+                    hex = "#98FB98",
+                },
+                border = {
+                    hex = "#98FB98",
+                },
+                fill = {
+                    hex = "#228B22",
+                },
+                tick = {
+                    grey = 0,
+                },
+                tick_width_multiplier = 3,
+            },
+            enabled = true,
+            height = 13,
+            margin_left = 10,
+            margin_right = 10,
+            margin_v = 3,
+            markers = {
+                top = {
+                    offset = 0,
+                    size = 50,
+                    type = "session",
+                },
+            },
+            style = "rounded",
+            type = "book",
+            unread_height = 7,
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+    },
+    schema_version = 5,
+}


### PR DESCRIPTION
**Balanced Color+** — Clean and informative.

Submitted by **Zork** via the bookends preset manager.

- Slug: `balanced-color`
- File: [`presets/balanced-color.lua`](../blob/submit/balanced-color-ti6q0s/presets/balanced-color.lua)