### PR TITLE
Submission: dongrc by logwet

### DIFF
--- a/presets/dongrc.lua
+++ b/presets/dongrc.lua
@@ -1,0 +1,370 @@
+-- Bookends preset: dongrc
+return {
+    author = "logwet",
+    defaults = {
+        font_scale = 100,
+        font_size = 14,
+        margin_bottom = 10,
+        margin_left = 18,
+        margin_right = 18,
+        margin_top = 10,
+        overlap_gap = 50,
+        truncation_priority = "sides",
+    },
+    description = "All the essentials, condensed into two lines and styled to disappear.",
+    name = "dongrc",
+    positions = {
+        bc = {
+            line_bar_chapter_ticks = {
+            },
+            line_bar_colors = {
+            },
+            line_bar_direction = {
+            },
+            line_bar_height = {
+            },
+            line_bar_markers = {
+            },
+            line_bar_style = {
+            },
+            line_bar_type = {
+            },
+            line_bar_unread_height = {
+            },
+            line_font_face = {
+            },
+            line_font_size = {
+                10,
+                10,
+            },
+            line_h_nudge = {
+            },
+            line_page_filter = {
+                "odd",
+                "even",
+            },
+            line_style = {
+            },
+            line_uppercase = {
+            },
+            line_v_nudge = {
+                5,
+                5,
+            },
+            lines = {
+                "%page_num of %page_count",
+                "%session_time • %session_pages Pages",
+            },
+        },
+        bl = {
+            line_bar_chapter_ticks = {
+            },
+            line_bar_colors = {
+            },
+            line_bar_direction = {
+            },
+            line_bar_height = {
+            },
+            line_bar_markers = {
+            },
+            line_bar_style = {
+            },
+            line_bar_type = {
+            },
+            line_bar_unread_height = {
+            },
+            line_font_face = {
+            },
+            line_font_size = {
+                10,
+                10,
+            },
+            line_h_nudge = {
+            },
+            line_page_filter = {
+                "odd",
+                "even",
+            },
+            line_style = {
+            },
+            line_uppercase = {
+            },
+            line_v_nudge = {
+                5,
+                5,
+            },
+            lines = {
+                "% %book_pct • %chap_pct",
+                "%pages_left/%page_count • %chap_pages_left/%chap_pages",
+            },
+        },
+        br = {
+            line_bar_chapter_ticks = {
+            },
+            line_bar_colors = {
+            },
+            line_bar_direction = {
+            },
+            line_bar_height = {
+            },
+            line_bar_markers = {
+            },
+            line_bar_style = {
+            },
+            line_bar_type = {
+            },
+            line_bar_unread_height = {
+            },
+            line_font_face = {
+            },
+            line_font_size = {
+                10,
+                10,
+            },
+            line_h_nudge = {
+            },
+            line_page_filter = {
+                "odd",
+                "even",
+            },
+            line_style = {
+            },
+            line_uppercase = {
+            },
+            line_v_nudge = {
+                5,
+                5,
+            },
+            lines = {
+                "Book time: %book_time_left",
+                "Chapter time: %chap_time_left",
+            },
+        },
+        tc = {
+            line_bar_chapter_ticks = {
+            },
+            line_bar_colors = {
+            },
+            line_bar_direction = {
+            },
+            line_bar_height = {
+            },
+            line_bar_markers = {
+            },
+            line_bar_style = {
+            },
+            line_bar_type = {
+            },
+            line_bar_unread_height = {
+            },
+            line_font_face = {
+            },
+            line_font_size = {
+                10,
+                10,
+            },
+            line_h_nudge = {
+            },
+            line_page_filter = {
+                "odd",
+                "even",
+            },
+            line_style = {
+                "italic",
+            },
+            line_uppercase = {
+            },
+            line_v_nudge = {
+                -5,
+                -5,
+            },
+            lines = {
+                "%title - %author",
+                "%chap_title",
+            },
+        },
+        tl = {
+            line_bar_chapter_ticks = {
+            },
+            line_bar_colors = {
+            },
+            line_bar_direction = {
+            },
+            line_bar_height = {
+            },
+            line_bar_markers = {
+            },
+            line_bar_style = {
+            },
+            line_bar_type = {
+            },
+            line_bar_unread_height = {
+            },
+            line_font_face = {
+            },
+            line_font_size = {
+                10,
+            },
+            line_h_nudge = {
+            },
+            line_page_filter = {
+            },
+            line_style = {
+            },
+            line_uppercase = {
+            },
+            line_v_nudge = {
+                -5,
+            },
+            lines = {
+                "%time_24h %weekday_short %date",
+            },
+        },
+        tr = {
+            line_bar_chapter_ticks = {
+            },
+            line_bar_colors = {
+            },
+            line_bar_direction = {
+            },
+            line_bar_height = {
+            },
+            line_bar_markers = {
+            },
+            line_bar_style = {
+            },
+            line_bar_type = {
+            },
+            line_bar_unread_height = {
+            },
+            line_font_face = {
+            },
+            line_font_size = {
+                10,
+            },
+            line_h_nudge = {
+            },
+            line_page_filter = {
+            },
+            line_style = {
+            },
+            line_uppercase = {
+            },
+            line_v_nudge = {
+                -5,
+            },
+            lines = {
+                "%mem %wifi %batt_icon%batt",
+            },
+        },
+    },
+    progress_bars = {
+        {
+            chapter_ticks = "off",
+            enabled = true,
+            height = 10,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "chapter",
+            v_anchor = "top",
+        },
+        {
+            chapter_ticks = "level2",
+            enabled = true,
+            height = 8,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            markers = {
+                bottom = {
+                    offset = 2,
+                    size = 20,
+                    style = "solid",
+                    type = "session",
+                },
+                top = {
+                    offset = 0,
+                    size = 20,
+                    style = "solid",
+                    type = "session",
+                },
+            },
+            style = "solid",
+            type = "book",
+            unread_height = 8,
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+    },
+    schema_version = 5,
+    text_color = {
+        grey = 64,
+    },
+}


### PR DESCRIPTION
**dongrc** — All the essentials, condensed into two lines and styled to disappear.

Submitted by **logwet** via the bookends preset manager.

- Slug: `dongrc`
- File: [`presets/dongrc.lua`](../blob/submit/dongrc-tksof7/presets/dongrc.lua)