### PR TITLE
Submission: Patrapong Preset by bookends

### DIFF
--- a/presets/patrapong-preset.lua
+++ b/presets/patrapong-preset.lua
@@ -1,6 +1,6 @@
 -- Bookends preset: Patrapong Preset
 return {
-    author = "bookends",
+    author = "Patrapong",
     defaults = {
         font_scale = 100,
         font_size = 15,
@@ -11,7 +11,7 @@ return {
         overlap_gap = 50,
         truncation_priority = "center",
     },
-    description = "Minimal starter — clock, page number, and a slim progress bar",
+    description = "Author and title along the top, page number and clock at the foot, above a slim chapter-ticked bar",
     name = "Patrapong Preset",
     positions = {
         bc = {

--- a/presets/patrapong-preset.lua
+++ b/presets/patrapong-preset.lua
@@ -1,0 +1,203 @@
+-- Bookends preset: Patrapong Preset
+return {
+    author = "bookends",
+    defaults = {
+        font_scale = 100,
+        font_size = 15,
+        margin_bottom = 10,
+        margin_left = 18,
+        margin_right = 18,
+        margin_top = 10,
+        overlap_gap = 50,
+        truncation_priority = "center",
+    },
+    description = "Minimal starter — clock, page number, and a slim progress bar",
+    name = "Patrapong Preset",
+    positions = {
+        bc = {
+            line_bar_chapter_ticks = {
+            },
+            line_bar_colors = {
+            },
+            line_bar_direction = {
+            },
+            line_bar_height = {
+            },
+            line_bar_markers = {
+            },
+            line_bar_style = {
+            },
+            line_bar_type = {
+            },
+            line_bar_unread_height = {
+            },
+            line_font_face = {
+            },
+            line_font_size = {
+                14,
+            },
+            line_h_nudge = {
+            },
+            line_page_filter = {
+            },
+            line_style = {
+            },
+            line_uppercase = {
+            },
+            line_v_nudge = {
+            },
+            lines = {
+                "%page_num / %page_count |  %time",
+            },
+        },
+        bl = {
+            lines = {
+            },
+        },
+        br = {
+            lines = {
+            },
+        },
+        tc = {
+            disabled = true,
+            line_font_size = {
+                14,
+            },
+            lines = {
+                "%time_12h",
+            },
+        },
+        tl = {
+            line_bar_chapter_ticks = {
+            },
+            line_bar_colors = {
+            },
+            line_bar_direction = {
+            },
+            line_bar_height = {
+            },
+            line_bar_markers = {
+            },
+            line_bar_style = {
+            },
+            line_bar_type = {
+            },
+            line_bar_unread_height = {
+            },
+            line_font_face = {
+            },
+            line_font_size = {
+                13,
+            },
+            line_h_nudge = {
+                -1,
+            },
+            line_page_filter = {
+            },
+            line_style = {
+            },
+            line_uppercase = {
+            },
+            line_v_nudge = {
+            },
+            lines = {
+                "%author  %title",
+            },
+        },
+        tr = {
+            lines = {
+            },
+        },
+    },
+    progress_bars = {
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 5,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "level1",
+            enabled = true,
+            height = 4,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 46,
+            style = "solid",
+            type = "book",
+            v_anchor = "top",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+    },
+    schema_version = 5,
+}


### PR DESCRIPTION
**Patrapong Preset** — Minimal starter — clock, page number, and a slim progress bar

Submitted by **bookends** via the bookends preset manager.

- Slug: `patrapong-preset`
- File: [`presets/patrapong-preset.lua`](../blob/submit/patrapong-preset-tksrlj/presets/patrapong-preset.lua)