### PR TITLE
Submission: minimalist sparkles - focus by bookends

### DIFF
--- a/presets/minimalist-sparkles-focus.lua
+++ b/presets/minimalist-sparkles-focus.lua
@@ -1,0 +1,269 @@
+-- Bookends preset: minimalist sparkles - focus
+return {
+    author = "bookends",
+    defaults = {
+        font_scale = 100,
+        font_size = 14,
+        margin_bottom = 10,
+        margin_left = 18,
+        margin_right = 18,
+        margin_top = 10,
+        overlap_gap = 50,
+        truncation_priority = "center",
+    },
+    description = "Minimalist with sparkles. Clock, book percentage, pages, and a barely-there progress bar!",
+    name = "minimalist sparkles - focus",
+    positions = {
+        bc = {
+            line_bar_chapter_ticks = {
+            },
+            line_bar_colors = {
+            },
+            line_bar_direction = {
+            },
+            line_bar_height = {
+            },
+            line_bar_markers = {
+            },
+            line_bar_style = {
+            },
+            line_bar_type = {
+            },
+            line_bar_unread_height = {
+            },
+            line_font_face = {
+            },
+            line_font_size = {
+            },
+            line_h_nudge = {
+            },
+            line_page_filter = {
+            },
+            line_style = {
+                "bold",
+            },
+            line_uppercase = {
+            },
+            line_v_nudge = {
+            },
+            lines = {
+                "— %page_num —",
+            },
+        },
+        bl = {
+            line_bar_chapter_ticks = {
+            },
+            line_bar_colors = {
+            },
+            line_bar_direction = {
+            },
+            line_bar_height = {
+            },
+            line_bar_markers = {
+            },
+            line_bar_style = {
+            },
+            line_bar_type = {
+            },
+            line_bar_unread_height = {
+            },
+            line_font_face = {
+            },
+            line_font_size = {
+            },
+            line_h_nudge = {
+            },
+            line_page_filter = {
+            },
+            line_style = {
+            },
+            line_uppercase = {
+            },
+            line_v_nudge = {
+            },
+            lines = {
+            },
+        },
+        br = {
+            disabled = true,
+            line_bar_chapter_ticks = {
+            },
+            line_bar_colors = {
+            },
+            line_bar_direction = {
+            },
+            line_bar_height = {
+            },
+            line_bar_markers = {
+            },
+            line_bar_style = {
+            },
+            line_bar_type = {
+            },
+            line_bar_unread_height = {
+            },
+            line_font_face = {
+            },
+            line_font_size = {
+            },
+            line_h_nudge = {
+            },
+            line_page_filter = {
+            },
+            line_style = {
+            },
+            line_uppercase = {
+            },
+            line_v_nudge = {
+            },
+            lines = {
+                "%book_pct",
+            },
+        },
+        tc = {
+            line_bar_chapter_ticks = {
+            },
+            line_bar_colors = {
+            },
+            line_bar_direction = {
+            },
+            line_bar_height = {
+            },
+            line_bar_markers = {
+            },
+            line_bar_style = {
+            },
+            line_bar_type = {
+            },
+            line_bar_unread_height = {
+            },
+            line_font_face = {
+            },
+            line_font_size = {
+                15,
+            },
+            line_h_nudge = {
+            },
+            line_page_filter = {
+            },
+            line_style = {
+                "bold",
+            },
+            line_uppercase = {
+            },
+            line_v_nudge = {
+                1,
+            },
+            lines = {
+                "—%time_12h—",
+            },
+        },
+        tl = {
+            lines = {
+            },
+        },
+        tr = {
+            lines = {
+            },
+        },
+    },
+    progress_bars = {
+        {
+            chapter_ticks = "off",
+            colors = {
+                bg = {
+                    hex = "#98FB98",
+                },
+                fill = {
+                    hex = "#0000CD",
+                },
+            },
+            enabled = true,
+            height = 7,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "chapter",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+        {
+            chapter_ticks = "off",
+            enabled = false,
+            height = 20,
+            margin_left = 0,
+            margin_right = 0,
+            margin_v = 0,
+            style = "solid",
+            type = "book",
+            v_anchor = "bottom",
+        },
+    },
+    schema_version = 5,
+}

--- a/presets/minimalist-sparkles-focus.lua
+++ b/presets/minimalist-sparkles-focus.lua
@@ -1,6 +1,6 @@
 -- Bookends preset: minimalist sparkles - focus
 return {
-    author = "bookends",
+    author = "Anon",
     defaults = {
         font_scale = 100,
         font_size = 14,


### PR DESCRIPTION
**minimalist sparkles - focus** — Minimalist with sparkles. Clock, book percentage, pages, and a barely-there progress bar!

Submitted by **bookends** via the bookends preset manager.

- Slug: `minimalist-sparkles-focus`
- File: [`presets/minimalist-sparkles-focus.lua`](../blob/submit/minimalist-sparkles-focus-tkyfpv/presets/minimalist-sparkles-focus.lua)